### PR TITLE
#137244143 build get exercise info endpoint

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,6 @@
-[run]
-omit = *migrations*
+[report]
+omit =
+    *migrations*
+    *tests*
+    *test_*
+    */management/commands/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - gulp lint
 
   # Regular application
-  - coverage run --source='.' ./manage.py test
+  - coverage run --source='.' ./manage.py test --parallel=20
 
 
   # Code coverage

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -23,12 +23,25 @@ from wger.exercises.models import (
     Equipment,
     ExerciseComment
 )
+from wger.utils.models import AbstractSubmissionModel
 
 
 class ExerciseSerializer(serializers.ModelSerializer):
     '''
     Exercise serializer
     '''
+
+    class Meta:
+        model = Exercise
+
+
+class ExerciseInfoSerializer(serializers.ModelSerializer):
+    '''
+    Exercise serializer
+    '''
+    language = serializers.CharField(source='language.full_name')
+    category = serializers.CharField(source='category.name')
+
     class Meta:
         model = Exercise
 

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 
 from rest_framework import serializers
+
 from wger.exercises.models import (
     Muscle,
     Exercise,
@@ -23,24 +24,12 @@ from wger.exercises.models import (
     Equipment,
     ExerciseComment
 )
-from wger.utils.models import AbstractSubmissionModel
 
 
 class ExerciseSerializer(serializers.ModelSerializer):
     '''
     Exercise serializer
     '''
-
-    class Meta:
-        model = Exercise
-
-
-class ExerciseInfoSerializer(serializers.ModelSerializer):
-    '''
-    Exercise serializer
-    '''
-    language = serializers.CharField(source='language.full_name')
-    category = serializers.CharField(source='category.name')
 
     class Meta:
         model = Exercise
@@ -68,6 +57,18 @@ class ExerciseImageSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = ExerciseImage
+
+
+class ExerciseInfoSerializer(serializers.ModelSerializer):
+    '''
+    Exercise serializer
+    '''
+    image = ExerciseImageSerializer(source='main_image')
+    description = serializers.StringRelatedField(source='description_clean')
+
+    class Meta:
+        model = Exercise
+        depth = 2
 
 
 class ExerciseCommentSerializer(serializers.ModelSerializer):

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -32,8 +32,8 @@ from wger.exercises.api.serializers import (
     ExerciseImageSerializer,
     ExerciseCategorySerializer,
     EquipmentSerializer,
-    ExerciseCommentSerializer
-)
+    ExerciseCommentSerializer,
+    ExerciseInfoSerializer)
 from wger.exercises.models import (
     Exercise,
     Equipment,
@@ -75,6 +75,26 @@ class ExerciseViewSet(viewsets.ModelViewSet):
         # Todo is it right to call set author after save?
         obj.set_author(self.request)
         obj.save()
+
+
+class ExerciseInfoViewSet(viewsets.ReadOnlyModelViewSet):
+    '''
+    API endpoint for exercise objects
+    '''
+    queryset = Exercise.objects.all().select_related()
+    serializer_class = ExerciseInfoSerializer
+    ordering_fields = '__all__'
+    filter_fields = ('category',
+                     'creation_date',
+                     'description',
+                     'language',
+                     'muscles',
+                     'muscles_secondary',
+                     'status',
+                     'name',
+                     'equipment',
+                     'license',
+                     'license_author')
 
 
 @api_view(['GET'])

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -79,7 +79,7 @@ class ExerciseViewSet(viewsets.ModelViewSet):
 
 class ExerciseInfoViewSet(viewsets.ReadOnlyModelViewSet):
     '''
-    API endpoint for exercise objects
+    API endpoint for an exercise details
     '''
     queryset = Exercise.objects.all().select_related()
     serializer_class = ExerciseInfoSerializer

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -18,6 +18,7 @@ from django.core import mail
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 
+from wger.core.tests import api_base_test
 from wger.core.tests.base_testcase import (
     STATUS_CODES_FAIL,
     WorkoutManagerTestCase,
@@ -531,3 +532,17 @@ class WorkoutCacheTestCase(WorkoutManagerTestCase):
 #             ],
 #             "name": "foobar",
 #             "status": "5"}
+
+class ExerciseApiTestCase(api_base_test.ApiGetTestCase, api_base_test.ApiBaseTestCase,
+                          WorkoutManagerTestCase):
+    url_resource_name = 'exercise-detail'
+    pk = 1
+    resource = Exercise
+    private_resource = False
+
+    def get_resource_name(self):
+        '''
+        Returns the name of the resource. The default is the name of the model
+        class used in lower letters
+        '''
+        return self.url_resource_name.lower()

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -16,6 +16,8 @@
 import six
 import logging
 import uuid
+
+from django.contrib.auth.models import User
 from django.core import mail
 
 from django.shortcuts import render, get_object_or_404
@@ -39,7 +41,10 @@ from django.views.generic import (
     CreateView,
     UpdateView
 )
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from wger.exercises.api.serializers import ExerciseSerializer
 from wger.manager.models import WorkoutLog
 from wger.exercises.models import (
     Exercise,
@@ -59,7 +64,6 @@ from wger.utils.widgets import (
 )
 from wger.config.models import LanguageConfig
 from wger.weight.helpers import process_log_entries
-
 
 logger = logging.getLogger(__name__)
 
@@ -159,10 +163,9 @@ class ExercisesEditAddView(WgerFormMixin):
     sidebar = 'exercise/form.html'
     title = ugettext_lazy('Add exercise')
     custom_js = 'wgerInitTinymce();'
-    clean_html = ('description', )
+    clean_html = ('description',)
 
     def get_form_class(self):
-
         # Define the exercise form here because only at this point during the request
         # have we access to the currently used language. In other places Django defaults
         # to 'en-us'.

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -17,7 +17,6 @@ import six
 import logging
 import uuid
 
-from django.contrib.auth.models import User
 from django.core import mail
 
 from django.shortcuts import render, get_object_or_404

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -103,6 +103,7 @@ router.register(r'setting-weightunit', core_api_views.WeightUnitViewSet, base_na
 
 # Exercises app
 router.register(r'exercise', exercises_api_views.ExerciseViewSet, base_name='exercise')
+router.register(r'exercise-detail', exercises_api_views.ExerciseInfoViewSet, base_name='exercise-detail')
 router.register(r'equipment', exercises_api_views.EquipmentViewSet, base_name='api')
 router.register(r'exercisecategory', exercises_api_views.ExerciseCategoryViewSet, base_name='exercisecategory')
 router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet, base_name='exerciseimage')


### PR DESCRIPTION
#### What does this PR do?
add url end points to get basic information on an exercise
#### Description of Task to be completed?
There should be a new read-only endpoint that collects all the information of an exercise such as muscles, category, images, etc

added URL endpoint:

      GET  /api/v2/exercise-detail
      GET /api/v2/exercise-detail/<id>

#### How should this be manually tested?
- After cloning the repository and set up the project based on the instruction `README`,
 run server with `python manage.py runserver`
- using postman client, enter url `http://localhost:8000/api/v2/exercise-detail/<id>` 
#### Any background context you want to provide?
Currently a user make several request to the api to get information about the muscle, image, category etc. The current endpoint `http://localhost:8000/api/v2/exercise/<id>` provides the id to the related stories
#### What are the relevant pivotal tracker stories?
`https://www.pivotaltracker.com/n/projects/1946489`
#### Screenshots (if appropriate)
#### Questions: