### PR TITLE
#137244137 Ft fix adding excercise mobile 

### DIFF
--- a/wger/manager/views/set.py
+++ b/wger/manager/views/set.py
@@ -68,7 +68,7 @@ def create(request, day_pk):
     # The difference is that the mobile form doesn't use the autocompleter for
     # exercises, but 2 dropdowns, one to filter by category and one to select
     # the exercises themselves.
-    if request.flavour == 'mobile':
+    if request.flavour == 'mobile' or request.session.get('flavour', None) == 'mobile':
         form_class = SetFormMobile
     else:
         form_class = SetForm


### PR DESCRIPTION
### What does this PR do?
fix error on adding exercise to workout log from mobile

### Description of Task to be completed?
Basically setting the website to display  mobile page on a computer via `?flavour=mobile` throws an error when trying to add an exercise to a workout day. The exercises and categories are not render for display

### How should this be manually tested?
Open the add workout page i.e `http://localhost:8000/en/workout/set/day/1/set/add/?flavour=mobile`. on reload the page should show a mobile view

### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/137244137