### PR TITLE
[chore #138021401]fix user exercise list view

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -75,7 +75,7 @@ $(document).ready(function() {
                     {% endif %}
                     </div>
                     <div class="media-body" style="position: absolute; top: 10px; left: 100px;">
-                        <h4 class="media-heading">{{ exercise.name }}</h4>
+                        <h4 class="media-heading">{{ exercise.name }} </h4>
                         <span class="text-muted">
                             {% for equipment in exercise.equipment.all %}
                                 {% trans equipment.name %}


### PR DESCRIPTION
What does this PR do?

Corrects the display of exercises. A user will only view exercises that are complete, while the Administrator shall view both incomplete and complete exercises.

Description of Task to be completed?

Feedback from local instance: Before all user (admin, registered users and temporary users) were seeing both incomplete and complete exercises. 

How should this be manually tested?

On adding a new exercise, which has the respective muscles affected and equipment to be used. On page redirect the exercise should be viewed on all accounts. While if an incomplete exercise is  added, only the admin should be able to view it on the exercise list page.

Any background context you want to provide?

This is probably due not properly filtering the exercise queries to be viewed by their respective users.
What are the relevant pivotal tracker stories?

https://www.pivotaltracker.com/story/show/138021401

